### PR TITLE
Fix MP4 export visual bugs and add Cancel button to ExportDialog

### DIFF
--- a/packages/editor/src/components/ExportDialog/ExportDialog.tsx
+++ b/packages/editor/src/components/ExportDialog/ExportDialog.tsx
@@ -6,6 +6,7 @@ import {
   createGifEncoder,
   downloadBlob,
   isWebCodecsSupported,
+  RenderCancelledError,
   type RenderProgress,
   type BrowserRendererOptions,
 } from '@rendervid/renderer-browser';
@@ -18,7 +19,7 @@ export interface ExportDialogProps {
 }
 
 type ExportFormat = 'mp4' | 'webm' | 'svg' | 'gif';
-type ExportState = 'idle' | 'exporting' | 'done' | 'error';
+type ExportState = 'idle' | 'exporting' | 'done' | 'error' | 'cancelled';
 
 export function ExportDialog({ template, inputValues, onClose }: ExportDialogProps) {
   const [format, setFormat] = useState<ExportFormat>(isWebCodecsSupported() ? 'mp4' : 'webm');
@@ -27,13 +28,23 @@ export function ExportDialog({ template, inputValues, onClose }: ExportDialogPro
   const [error, setError] = useState<string | null>(null);
   const [resultSize, setResultSize] = useState<number>(0);
   const rendererRef = useRef<ReturnType<typeof createBrowserRenderer> | null>(null);
+  const cancelRequestedRef = useRef(false);
+  const [isCancelling, setIsCancelling] = useState(false);
 
   const webCodecsAvailable = isWebCodecsSupported();
+
+  const handleCancel = useCallback(() => {
+    cancelRequestedRef.current = true;
+    setIsCancelling(true);
+    rendererRef.current?.cancel();
+  }, []);
 
   const handleExport = useCallback(async () => {
     setState('exporting');
     setError(null);
     setProgress(null);
+    cancelRequestedRef.current = false;
+    setIsCancelling(false);
 
     try {
       const registry = buildRegistry(template.customComponents);
@@ -62,8 +73,12 @@ export function ExportDialog({ template, inputValues, onClose }: ExportDialogPro
       renderer.dispose();
       rendererRef.current = null;
     } catch (err) {
-      setState('error');
-      setError(err instanceof Error ? err.message : String(err));
+      if (err instanceof RenderCancelledError || cancelRequestedRef.current) {
+        setState('cancelled');
+      } else {
+        setState('error');
+        setError(err instanceof Error ? err.message : String(err));
+      }
       rendererRef.current?.dispose();
       rendererRef.current = null;
     }
@@ -123,6 +138,8 @@ export function ExportDialog({ template, inputValues, onClose }: ExportDialogPro
     setState('exporting');
     setError(null);
     setProgress(null);
+    cancelRequestedRef.current = false;
+    setIsCancelling(false);
 
     try {
       const registry = buildRegistry(template.customComponents);
@@ -147,6 +164,7 @@ export function ExportDialog({ template, inputValues, onClose }: ExportDialogPro
       // Render each frame using the same pattern as video export
       // We need to use renderImage for each frame to get canvas data
       for (let frame = 0; frame < totalFrames; frame++) {
+        if (cancelRequestedRef.current) throw new RenderCancelledError();
         const frameStartTime = performance.now();
 
         // Render frame and get image blob
@@ -202,8 +220,12 @@ export function ExportDialog({ template, inputValues, onClose }: ExportDialogPro
       renderer.dispose();
       rendererRef.current = null;
     } catch (err) {
-      setState('error');
-      setError(err instanceof Error ? err.message : String(err));
+      if (err instanceof RenderCancelledError || cancelRequestedRef.current) {
+        setState('cancelled');
+      } else {
+        setState('error');
+        setError(err instanceof Error ? err.message : String(err));
+      }
       rendererRef.current?.dispose();
       rendererRef.current = null;
     }
@@ -298,10 +320,16 @@ export function ExportDialog({ template, inputValues, onClose }: ExportDialogPro
         {state === 'exporting' && progress && (
           <div style={sectionStyle}>
             <div style={{ fontSize: '13px', color: '#ccc', marginBottom: '8px' }}>
-              {progress.phase === 'capturing' && `Rendering frames... ${progressPercent}%`}
-              {progress.phase === 'encoding' && 'Encoding...'}
-              {progress.phase === 'muxing' && 'Creating file...'}
-              {progress.phase === 'complete' && 'Complete!'}
+              {cancelRequestedRef.current
+                ? 'Cancelling...'
+                : (
+                  <>
+                    {progress.phase === 'capturing' && `Rendering frames... ${progressPercent}%`}
+                    {progress.phase === 'encoding' && 'Encoding...'}
+                    {progress.phase === 'muxing' && 'Creating file...'}
+                    {progress.phase === 'complete' && 'Complete!'}
+                  </>
+                )}
             </div>
 
             {/* Progress bar */}
@@ -313,12 +341,43 @@ export function ExportDialog({ template, inputValues, onClose }: ExportDialogPro
               <span>Frame {progress.currentFrame} / {progress.totalFrames}</span>
               {eta !== undefined && eta > 0 && <span>~{Math.ceil(eta)}s remaining</span>}
             </div>
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '14px' }}>
+              <button
+                onClick={handleCancel}
+                disabled={isCancelling}
+                style={{ ...cancelButtonStyle, opacity: isCancelling ? 0.5 : 1 }}
+              >
+                {isCancelling ? 'Cancelling…' : 'Cancel'}
+              </button>
+            </div>
           </div>
         )}
 
         {state === 'exporting' && !progress && (
           <div style={sectionStyle}>
-            <div style={{ fontSize: '13px', color: '#ccc' }}>Preparing...</div>
+            <div style={{ fontSize: '13px', color: '#ccc' }}>
+              {isCancelling ? 'Cancelling...' : 'Preparing...'}
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '14px' }}>
+              <button
+                onClick={handleCancel}
+                disabled={isCancelling}
+                style={{ ...cancelButtonStyle, opacity: isCancelling ? 0.5 : 1 }}
+              >
+                {isCancelling ? 'Cancelling…' : 'Cancel'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {state === 'cancelled' && (
+          <div style={sectionStyle}>
+            <div style={{ fontSize: '14px', color: '#fbbf24', marginBottom: '8px' }}>Export cancelled</div>
+            <div style={{ display: 'flex', gap: '8px', marginTop: '12px' }}>
+              <button onClick={() => setState('idle')} style={exportButtonStyle}>Try Again</button>
+              <button onClick={onClose} style={imageButtonStyle}>Close</button>
+            </div>
           </div>
         )}
 
@@ -440,6 +499,17 @@ const imageButtonStyle: React.CSSProperties = {
   backgroundColor: '#444',
   color: '#fff',
   border: 'none',
+  borderRadius: '6px',
+  cursor: 'pointer',
+};
+
+const cancelButtonStyle: React.CSSProperties = {
+  padding: '8px 18px',
+  fontSize: '12px',
+  fontWeight: 500,
+  backgroundColor: 'transparent',
+  color: '#f87171',
+  border: '1px solid #f87171',
   borderRadius: '6px',
   cursor: 'pointer',
 };

--- a/packages/editor/src/components/VideoEditor.tsx
+++ b/packages/editor/src/components/VideoEditor.tsx
@@ -423,7 +423,9 @@ export function VideoEditor({
               }}
               title="Go to start"
             >
-              ⏮
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M6 5h2v14H6zM9.5 12l10 7V5z" />
+              </svg>
             </button>
             <button
               onClick={togglePlay}
@@ -434,10 +436,21 @@ export function VideoEditor({
                 border: 'none',
                 borderRadius: '4px',
                 cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
               title="Play/Pause (Space)"
             >
-              {isPlaying ? '⏸' : '▶️'}
+              {isPlaying ? (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M6 5h4v14H6zM14 5h4v14h-4z" />
+                </svg>
+              ) : (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              )}
             </button>
             <button
               onClick={() => setCurrentFrame(totalFrames - 1)}
@@ -451,7 +464,9 @@ export function VideoEditor({
               }}
               title="Go to end"
             >
-              ⏭
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M16 5h2v14h-2zM4.5 19l10-7-10-7z" />
+              </svg>
             </button>
 
             <span style={{ fontSize: '12px', color: '#999', marginLeft: '8px' }}>

--- a/packages/renderer-browser/package.json
+++ b/packages/renderer-browser/package.json
@@ -27,10 +27,11 @@
     "@react-three/drei": "^9.122.0",
     "@react-three/fiber": "^8.18.0",
     "@rendervid/core": "workspace:*",
+    "@rendervid/physics": "workspace:*",
+    "html-to-image": "^1.11.13",
     "html2canvas": "^1.4.1",
     "mp4-muxer": "^5.2.2",
-    "three": "^0.163.0",
-    "@rendervid/physics": "workspace:*"
+    "three": "^0.163.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/renderer-browser/src/encoder/capturer.ts
+++ b/packages/renderer-browser/src/encoder/capturer.ts
@@ -1,4 +1,5 @@
 import html2canvas from 'html2canvas';
+import { toCanvas as htmlToImageCanvas } from 'html-to-image';
 
 export interface CaptureOptions {
   /** Target element to capture */
@@ -252,33 +253,77 @@ export function createFrameCapturer(): FrameCapturer {
     const snapshots = snapshotWebGLCanvases(options.element);
 
     const scale = options.scale ?? 1;
-    // html2canvas treats `width`/`height` as the SOURCE area to capture and
-    // creates a canvas of (width*scale) × (height*scale). However when both
-    // width and scale are provided, content can end up rendering at 1:1 in the
-    // top-left of an oversized canvas. The reliable way to get a high-DPI
-    // capture is to omit width/height and rely on the element's bounding box,
-    // letting `scale` do all the DPI multiplication.
-    let canvas = await html2canvas(options.element, {
-      backgroundColor: options.backgroundColor ?? null,
-      scale,
-      useCORS: options.useCORS ?? true,
-      proxy: options.proxy,
-      logging: false,
-      allowTaint: false,
-      foreignObjectRendering: false,
-      imageTimeout: 15000,
-      removeContainer: true,
-      onclone: (_doc: Document, clonedElement: HTMLElement) => {
-        // Force the cloned root to be fully visible for capture, in case the
-        // live element is hidden / opacity:0 (e.g. an off-screen render
-        // container). html2canvas otherwise returns an empty canvas.
-        const cloneRoot = clonedElement as HTMLElement;
-        cloneRoot.style.opacity = '1';
-        cloneRoot.style.visibility = 'visible';
-        cloneRoot.style.display = 'block';
-        applyWebGLSnapshots(options.element, clonedElement, snapshots);
-      },
-    });
+    // Primary capture path: html-to-image's foreignObject SVG renderer.
+    // Unlike html2canvas (which re-implements CSS layout/paint and gets
+    // opacity, gradients, blend modes, and filters subtly wrong), this
+    // serialises the element subtree into an <foreignObject> inside an
+    // <svg> and rasterises via the browser's native renderer. The result
+    // matches what the user sees on screen pixel-for-pixel — no more
+    // washed-out crossfades or ghosted opacity transitions.
+    let canvas: HTMLCanvasElement;
+    try {
+      canvas = await htmlToImageCanvas(options.element, {
+        canvasWidth: Math.round(options.width * scale),
+        canvasHeight: Math.round(options.height * scale),
+        pixelRatio: scale,
+        backgroundColor: options.backgroundColor,
+        cacheBust: false,
+        skipFonts: false,
+        // Force the captured root to be fully visible — handles off-screen
+        // render containers that have opacity:0 / display:none / etc.
+        style: { opacity: '1', visibility: 'visible', display: 'block' },
+        // Skip preserving WebGL contexts — we snapshot them separately.
+        filter: () => true,
+      });
+      // html-to-image doesn't run an onclone callback, so apply WebGL
+      // snapshots after the fact by overlaying them on the produced canvas.
+      // (For most templates there are no canvases, so this is a no-op.)
+      if (snapshots.size > 0) {
+        const ctx = canvas.getContext('2d');
+        if (ctx) {
+          const liveCanvases = options.element.querySelectorAll('canvas');
+          const elementRect = options.element.getBoundingClientRect();
+          for (const original of liveCanvases) {
+            const snap = snapshots.get(original);
+            if (!snap) continue;
+            const r = original.getBoundingClientRect();
+            const off = document.createElement('canvas');
+            off.width = snap.width;
+            off.height = snap.height;
+            off.getContext('2d')?.putImageData(snap, 0, 0);
+            ctx.drawImage(
+              off,
+              (r.left - elementRect.left) * scale,
+              (r.top - elementRect.top) * scale,
+              r.width * scale,
+              r.height * scale,
+            );
+          }
+        }
+      }
+    } catch (err) {
+      // Fallback to html2canvas if foreignObject path fails (e.g. tainted
+      // images or other security restrictions on the page).
+      console.warn('[capturer] html-to-image failed, falling back to html2canvas:', err);
+      canvas = await html2canvas(options.element, {
+        backgroundColor: options.backgroundColor ?? null,
+        scale,
+        useCORS: options.useCORS ?? true,
+        proxy: options.proxy,
+        logging: false,
+        allowTaint: false,
+        foreignObjectRendering: false,
+        imageTimeout: 15000,
+        removeContainer: true,
+        onclone: (_doc: Document, clonedElement: HTMLElement) => {
+          const cloneRoot = clonedElement as HTMLElement;
+          cloneRoot.style.opacity = '1';
+          cloneRoot.style.visibility = 'visible';
+          cloneRoot.style.display = 'block';
+          applyWebGLSnapshots(options.element, clonedElement, snapshots);
+        },
+      });
+    }
 
     // Verify the canvas dims match the requested target. If html2canvas
     // produced something smaller (e.g. when the source element has zero

--- a/packages/renderer-browser/src/index.ts
+++ b/packages/renderer-browser/src/index.ts
@@ -2,6 +2,7 @@
 export {
   BrowserRenderer,
   createBrowserRenderer,
+  RenderCancelledError,
   type BrowserRendererOptions,
   type RenderVideoOptions,
   type RenderImageOptions,

--- a/packages/renderer-browser/src/renderer/BrowserRenderer.tsx
+++ b/packages/renderer-browser/src/renderer/BrowserRenderer.tsx
@@ -10,6 +10,18 @@ import { createMp4Muxer } from '../encoder/muxer';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CustomComponentType = React.ComponentType<any>;
 
+/**
+ * Thrown by renderVideo() when the caller invokes BrowserRenderer.cancel()
+ * mid-render. Distinct error class so UIs can show "cancelled" instead of
+ * a generic failure.
+ */
+export class RenderCancelledError extends Error {
+  constructor(message = 'Render cancelled') {
+    super(message);
+    this.name = 'RenderCancelledError';
+  }
+}
+
 export interface BrowserRendererOptions {
   /** Target container element */
   container?: HTMLElement;
@@ -103,6 +115,7 @@ export class BrowserRenderer {
   private container: HTMLElement;
   private root: Root | null = null;
   private isRendering = false;
+  private cancelRequested = false;
   private registry: ComponentRegistry;
   private processor: TemplateProcessor;
 
@@ -160,6 +173,7 @@ export class BrowserRenderer {
     }
 
     this.isRendering = true;
+    this.cancelRequested = false;
 
     try {
       const { template, inputs = {}, format = 'mp4', bitrate, renderScale = 1, onProgress, onFrame } = options;
@@ -291,6 +305,7 @@ export class BrowserRenderer {
 
     // Render each frame
     for (let frame = 0; frame < totalFrames; frame++) {
+      if (this.cancelRequested) throw new RenderCancelledError();
       const frameStartTime = performance.now();
 
       // Render frame to DOM at native template dimensions
@@ -427,6 +442,10 @@ export class BrowserRenderer {
 
     // Render each frame
     for (let frame = 0; frame < totalFrames; frame++) {
+      if (this.cancelRequested) {
+        try { mediaRecorder.stop(); } catch { /* already stopped */ }
+        throw new RenderCancelledError();
+      }
       const frameStartTime = performance.now();
 
       // Render frame to DOM
@@ -667,6 +686,26 @@ export class BrowserRenderer {
       // Font loading failed, but we continue with fallbacks
       console.warn('[BrowserRenderer] Font loading failed, using fallbacks:', error);
     }
+  }
+
+  /**
+   * Request cancellation of the in-flight render. The per-frame loops in
+   * renderWithWebCodecs / renderWithMediaRecorder check this flag at the
+   * top of each iteration and bail out by throwing a RenderCancelledError,
+   * which the caller (ExportDialog) can catch to distinguish a user-cancel
+   * from an actual failure.
+   */
+  cancel(): void {
+    if (this.isRendering) {
+      this.cancelRequested = true;
+    }
+  }
+
+  /**
+   * Whether the renderer is currently producing frames.
+   */
+  isActive(): boolean {
+    return this.isRendering;
   }
 
   /**

--- a/packages/renderer-browser/src/renderer/BrowserRenderer.tsx
+++ b/packages/renderer-browser/src/renderer/BrowserRenderer.tsx
@@ -172,16 +172,26 @@ export class BrowserRenderer {
       await this.loadFonts(processedTemplate);
 
       const { width, height, fps = 30 } = processedTemplate.output;
+      // Capture-time background. If the template declares an output
+      // backgroundColor, use it; otherwise default to white. This is what
+      // html2canvas composites partially-transparent layers against — the
+      // previous implicit-null left an alpha canvas that the MP4 encoder
+      // back-filled with black, which made every opacity-driven crossfade
+      // visibly washed out / ghosted on light-themed templates.
+      const captureBg = (processedTemplate.output as { backgroundColor?: string }).backgroundColor || '#FFFFFF';
       const scenes = processedTemplate.composition.scenes;
       const totalFrames = calculateTotalFrames(scenes, fps);
       const duration = totalFrames / fps;
 
-      // Create render container
+      // Create render container. Give it the same opaque background as the
+      // capture-time bg so any uncovered pixel during reflow paints to it
+      // instead of bleeding through.
       const renderContainer = document.createElement('div');
       renderContainer.style.cssText = `
         width: ${width}px;
         height: ${height}px;
         overflow: hidden;
+        background: ${captureBg};
       `;
       this.container.appendChild(renderContainer);
 
@@ -200,7 +210,7 @@ export class BrowserRenderer {
         result = await this.renderWithWebCodecs(
           scenes,
           renderContainer,
-          { width, height, fps, totalFrames, duration, bitrate, renderScale },
+          { width, height, fps, totalFrames, duration, bitrate, renderScale, captureBg },
           capturer,
           onProgress,
           onFrame
@@ -209,7 +219,7 @@ export class BrowserRenderer {
         result = await this.renderWithMediaRecorder(
           scenes,
           renderContainer,
-          { width, height, fps, totalFrames, duration, renderScale },
+          { width, height, fps, totalFrames, duration, renderScale, captureBg },
           capturer,
           onProgress,
           onFrame
@@ -230,12 +240,12 @@ export class BrowserRenderer {
   private async renderWithWebCodecs(
     scenes: Scene[],
     container: HTMLElement,
-    config: { width: number; height: number; fps: number; totalFrames: number; duration: number; bitrate?: number; renderScale?: number },
+    config: { width: number; height: number; fps: number; totalFrames: number; duration: number; bitrate?: number; renderScale?: number; captureBg?: string },
     capturer: ReturnType<typeof createFrameCapturer>,
     onProgress?: (progress: RenderProgress) => void,
     onFrame?: (frame: number, totalFrames: number) => void
   ): Promise<VideoResult> {
-    const { width, height, fps, totalFrames, duration, bitrate, renderScale = 1 } = config;
+    const { width, height, fps, totalFrames, duration, bitrate, renderScale = 1, captureBg = '#FFFFFF' } = config;
 
     // Encoder/muxer dimensions are scaled (e.g. 1080p × 2 = 4K).
     // The DOM is still rendered at native (width, height); html2canvas
@@ -295,6 +305,7 @@ export class BrowserRenderer {
         width,
         height,
         scale: renderScale,
+        backgroundColor: captureBg,
       });
 
       // Encode frame
@@ -371,12 +382,12 @@ export class BrowserRenderer {
   private async renderWithMediaRecorder(
     scenes: Scene[],
     container: HTMLElement,
-    config: { width: number; height: number; fps: number; totalFrames: number; duration: number; renderScale?: number },
+    config: { width: number; height: number; fps: number; totalFrames: number; duration: number; renderScale?: number; captureBg?: string },
     capturer: ReturnType<typeof createFrameCapturer>,
     onProgress?: (progress: RenderProgress) => void,
     onFrame?: (frame: number, totalFrames: number) => void
   ): Promise<VideoResult> {
-    const { width, height, fps, totalFrames, duration, renderScale = 1 } = config;
+    const { width, height, fps, totalFrames, duration, renderScale = 1, captureBg = '#FFFFFF' } = config;
 
     const encWidth = Math.round(width * renderScale);
     const encHeight = Math.round(height * renderScale);
@@ -430,9 +441,16 @@ export class BrowserRenderer {
         width,
         height,
         scale: renderScale,
+        backgroundColor: captureBg,
       });
 
-      // Draw to MediaRecorder canvas
+      // Paint the recorder canvas to the capture-time bg first, then draw
+      // the captured frame on top. Without the fillRect, drawImage of a
+      // partially-transparent capture would composite over the previous
+      // frame's leftover pixels, leaving smear artefacts at element edges
+      // where opacity changes between frames.
+      ctx.fillStyle = captureBg;
+      ctx.fillRect(0, 0, encWidth, encHeight);
       ctx.drawImage(capturedCanvas, 0, 0, encWidth, encHeight);
 
       // Wait for frame timing

--- a/packages/renderer-browser/src/renderer/SceneRenderer.tsx
+++ b/packages/renderer-browser/src/renderer/SceneRenderer.tsx
@@ -267,8 +267,12 @@ function TransitionRenderer({
   const getTransitionStyle = (): React.CSSProperties => {
     switch (transitionType) {
       case 'fade': {
+        // Keep outgoing fully opaque; the incoming scene fades in on top.
+        // Fading both simultaneously (outgoing 1-p, incoming p) leaves
+        // 25% body-bg leakthrough at mid-transition (50% × 50% transparency
+        // stacked), producing a washed-out "ghost" frame.
         return {
-          opacity: 1 - progress,
+          opacity: 1,
         };
       }
       case 'slide': {

--- a/packages/renderer-browser/src/renderer/SceneRenderer.tsx
+++ b/packages/renderer-browser/src/renderer/SceneRenderer.tsx
@@ -88,7 +88,13 @@ export function SceneRenderer({
         width,
         height,
         overflow: 'hidden',
-        backgroundColor: '#000000',
+        // No hardcoded background. The scene's own backgroundColor (if any)
+        // is spread in via backgroundStyle below; otherwise the container
+        // stays transparent and the parent (BrowserRenderer / template
+        // output bg) shows through. Hardcoding #000 here meant any layer
+        // with opacity < 1 composited against black, producing visibly
+        // washed-out / desaturated content during phase crossfades on
+        // light-themed templates.
         ...backgroundStyle,
       }}
     >
@@ -179,12 +185,14 @@ export function TemplateRenderer({
   }
 
   if (!currentScene) {
+    // Empty/no-scene fallback — keep transparent so the parent decides
+    // the canvas bg (was previously hardcoded #000, which forced a black
+    // tail on any export that ran past the last scene's endFrame).
     return (
       <div
         style={{
           width,
           height,
-          backgroundColor: '#000000',
         }}
       />
     );

--- a/packages/renderer-browser/src/renderer/index.ts
+++ b/packages/renderer-browser/src/renderer/index.ts
@@ -1,6 +1,7 @@
 export {
   BrowserRenderer,
   createBrowserRenderer,
+  RenderCancelledError,
   type BrowserRendererOptions,
   type RenderVideoOptions,
   type RenderImageOptions,

--- a/packages/renderer-node/src/frame-capturer.ts
+++ b/packages/renderer-node/src/frame-capturer.ts
@@ -294,6 +294,12 @@ export class FrameCapturer {
   private generateRenderHTML(): string {
     const { template, inputs = {}, registry } = this.config;
     const { width, height } = template.output;
+    // Use the template's declared output background as the page background.
+    // Falling back to black caused two visible bugs: (1) "greying" mid-crossfade,
+    // because both scenes alpha-blend over the body during a fade transition and
+    // the math only nets to white when the body is also white, (2) any
+    // momentary uncovered pixel during reflow paints as black for a frame.
+    const pageBg = template.output.backgroundColor || '#FFFFFF';
 
     // Serialize template and inputs for the renderer
     const templateJson = JSON.stringify(template);
@@ -314,18 +320,29 @@ export class FrameCapturer {
       margin: 0;
       padding: 0;
       box-sizing: border-box;
+      /* Disable text selection globally — headless Chromium can leave a
+         residual selection state after setContent / font load / resize that
+         renders a blue selection-highlight rectangle BEHIND any element using
+         the gradient-text trick (-webkit-background-clip: text +
+         -webkit-text-fill-color: transparent). Killing selection at the source. */
+      -webkit-user-select: none !important;
+      user-select: none !important;
     }
+    /* Even if a selection somehow appears, make its highlight invisible. */
+    ::selection { background: transparent !important; color: inherit !important; }
+    ::-moz-selection { background: transparent !important; color: inherit !important; }
     html, body {
       width: ${width}px;
       height: ${height}px;
       overflow: hidden;
-      background: #000;
+      background: ${pageBg};
     }
     #root {
       width: ${width}px;
       height: ${height}px;
       position: relative;
       overflow: hidden;
+      background: ${pageBg};
     }
   </style>
 </head>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
         version: 29.7.0(@types/node@22.19.11)
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.3)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.11))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.11))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -306,6 +306,37 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0)
 
+  packages/mcp-preview:
+    dependencies:
+      '@rendervid/core':
+        specifier: workspace:*
+        version: link:../core
+      '@rendervid/player':
+        specifier: workspace:*
+        version: link:../player
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: 18.3.0
+        version: 18.3.0
+      '@types/react-dom':
+        specifier: 18.3.0
+        version: 18.3.0
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.4.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.1
+        version: 6.4.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0)
+
   packages/physics:
     dependencies:
       '@dimforge/rapier3d-compat':
@@ -407,6 +438,9 @@ importers:
       '@rendervid/physics':
         specifier: workspace:*
         version: link:../physics
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       html2canvas:
         specifier: ^1.4.1
         version: 1.4.1
@@ -4210,6 +4244,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -9512,21 +9549,21 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@25.2.3)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0)
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -11391,6 +11428,8 @@ snapshots:
   html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
+
+  html-to-image@1.11.13: {}
 
   html-void-elements@3.0.0: {}
 
@@ -13587,7 +13626,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.3)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.11))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.11))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -13605,7 +13644,6 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      esbuild: 0.27.3
       jest-util: 29.7.0
 
   tslib@2.8.1: {}
@@ -13877,7 +13915,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13910,6 +13948,20 @@ snapshots:
       '@types/node': 25.2.3
       fsevents: 2.3.3
 
+  vite@6.4.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.11
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      tsx: 4.21.0
+
   vite@6.4.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
@@ -13920,20 +13972,6 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.2.3
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      tsx: 4.21.0
-
-  vite@7.3.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.19.11
       fsevents: 2.3.3
       jiti: 1.21.7
       tsx: 4.21.0
@@ -14076,7 +14114,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -14094,7 +14132,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -14117,7 +14155,7 @@ snapshots:
   vitest@4.0.18(@types/node@25.2.3)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@23.2.0(canvas@3.2.1))(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -14134,7 +14172,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@1.21.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.2.3


### PR DESCRIPTION
## Summary

- Eliminate several classes of visual bugs that caused exported MP4s to diverge from the localhost preview: washed-out / ghosted crossfades on light-themed templates, black flashes between frames, a blue selection highlight bleeding through gradient text, and mid-transition body leakthrough on fade transitions.
- Replace `html2canvas` with `html-to-image` as the primary browser-export capture path so exported pixels match the preview using the browser's native renderer. `html2canvas` is retained as a fallback for tainted-image edge cases.
- Add a Cancel button to the Export Video / GIF dialog so in-progress renders can be aborted cleanly without leaking the off-screen render container or leaving the WebCodecs encoder mid-flush.
- Minor: replace inconsistent unicode emoji playback glyphs in the editor toolbar with inline SVG icons.

## Commits

1. **`45704de` fix: eliminate three visual bugs in MP4 exports** — `renderer-node` body bg now reads `template.output.backgroundColor` instead of being hardcoded to `#000`; disables global `user-select` to kill a residual headless-Chromium selection highlight that rendered behind gradient text; rewrites `SceneRenderer` fade transition so the outgoing scene stays at full opacity and the incoming scene fades in on top, eliminating the 25% body leakthrough at mid-transition.
2. **`a3889a5` fix(renderer-browser): kill hardcoded black scene bg that washed out exports** — three independent black-fills in the browser-export pipeline (`SceneRenderer` scene container, no-currentScene fallback, `html2canvas` transparent-canvas + alpha back-fill) compounded to produce desaturated MP4 exports on light templates. `BrowserRenderer` / `capturer.ts` now thread `template.output.backgroundColor` (defaulting to `#FFFFFF`) through the off-screen container, `html2canvas`, and the `MediaRecorder` canvas pre-fill.
3. **`e00398f` fix: replace html2canvas with html-to-image for accurate exports** — switches the primary capture path to `html-to-image`, which rasterises the subtree via a `foreignObject` SVG using the browser's native renderer, so exported pixels match the live preview. WebGL canvas snapshots are now overlaid after the fact (no `onclone` hook in `html-to-image`) to preserve `ThreeLayer` / particle parity. Also replaces the inconsistent emoji playback glyphs in `VideoEditor.tsx` with inline SVG.
4. **`4e6b349` feat(export): add Cancel button to ExportDialog with clean abort** — adds `cancel()` / `isActive()` / `cancelRequested` to `BrowserRenderer`; both per-frame loops (`renderWithWebCodecs` and `renderWithMediaRecorder`) check the flag at the top of each iteration and throw a new `RenderCancelledError` so the dialog can distinguish a user-cancel from a real failure. The `MediaRecorder` loop also calls `mediaRecorder.stop()` before throwing. `ExportDialog` wires the new error class through both video and GIF paths and adds a "cancelled" state with amber styling.

## Test plan

- [ ] Light-themed template with an opacity-driven crossfade — export MP4 from the editor playground; confirm exported frames match the live preview pixel-for-pixel (no desaturation / ghosting).
- [ ] Dark-themed template — confirm exports still render correctly (no regression from the new `output.backgroundColor` threading).
- [ ] Gradient text via `-webkit-background-clip: text` + `-webkit-text-fill-color: transparent` — confirm no blue selection rectangle behind the text in the exported MP4.
- [ ] Multi-scene template with `transition: { type: 'fade' }` — confirm no grey / body leakthrough at mid-transition.
- [ ] Export Video and Export GIF dialogs — start a render, click Cancel mid-render, confirm dialog returns to the "cancelled" state and no off-screen render container or encoder is leaked.
- [ ] WebGL / `ThreeLayer` scene — confirm the canvas snapshot still composites correctly through the `html-to-image` path.
- [ ] `renderer-node` path — render a template with an explicit `output.backgroundColor` and confirm the rendered body bg matches.